### PR TITLE
Add more utils for bytes

### DIFF
--- a/util.go
+++ b/util.go
@@ -140,12 +140,35 @@ func Shasum(data []byte) string {
 	return hex.EncodeToString(bs)
 }
 
+func BytesToKB(size int) float32 {
+	return float32(size) / 1000
+}
+
 func BytesToMB(size int) float32 {
-	return ((float32(size) / 1000) / 1000)
+	return BytesToKB(size) / 1000
 }
 
 func BytesToGB(size int) float32 {
 	return BytesToMB(size) / 1000
+}
+
+func BytesToTB(size int) float32 {
+	return BytesToGB(size) / 1000
+}
+
+func HumanizeBytes(size int) string {
+	switch {
+	case size < 1_000:
+		return fmt.Sprintf("%dB", size)
+	case size < 1_000_000:
+		return fmt.Sprintf("%.1fKB", BytesToKB(size))
+	case size < 1_000_000_000:
+		return fmt.Sprintf("%.1fMB", BytesToMB(size))
+	case size < 1_000_000_000_000:
+		return fmt.Sprintf("%.1fGB", BytesToGB(size))
+	default:
+		return fmt.Sprintf("%.1fTB", BytesToTB(size))
+	}
 }
 
 // https://stackoverflow.com/a/46964105


### PR DESCRIPTION
These can help improve error messages like this one: 

```
stream size exceeded: 0.00mb: storage size 2.12mb, storage max 20000.00mb, file max 50.00mb, special file max 0.00mb
```

Ref: https://github.com/picosh/pico/blob/910a7a5d65bbcd5eb69c9ce921f7c653a2061c61/filehandlers/assets/handler.go#L373

Ref: https://github.com/picosh/pico/pull/150